### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -664,7 +664,8 @@ export default {
 			
 			if (notlsresponseBody && noTLS == 'true') {
 				combinedContent += '\n' + notlsresponseBody;
-				console.log("notlsresponseBody: " + notlsresponseBody);
+				const sanitizedNotlsResponseBody = notlsresponseBody.replace(/uuid=[^&]+/, 'uuid=REDACTED');
+				console.log("notlsresponseBody: " + sanitizedNotlsResponseBody);
 			}
 			
 			if (协议类型 == 'Trojan' && (userAgent.includes('surge') || (format === 'surge' && !userAgent.includes('subconverter')) ) && !userAgent.includes('cf-workers-sub')) {


### PR DESCRIPTION
Fixes [https://github.com/shulng/WorkerVless2sub/security/code-scanning/1](https://github.com/shulng/WorkerVless2sub/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information directly. Instead of logging the entire `notlsresponseBody`, we can log a sanitized version that excludes sensitive data. This can be achieved by either redacting the sensitive parts or by not logging the sensitive information at all.

1. Identify the lines where sensitive information is logged.
2. Replace the logging of sensitive information with a sanitized version or remove the logging if it is not necessary.
3. Ensure that the fix does not alter the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
